### PR TITLE
fix: allow pubsub rpc to be processed concurrently

### DIFF
--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -67,6 +67,7 @@
     "libp2p-crypto": "^0.19.5",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.1.2",
+    "p-queue": "^6.6.2",
     "peer-id": "^0.15.0",
     "protobufjs": "^6.10.2",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
To allow processing pubsub messages that have steps that are slow but
async, process the messages in a queue.

Makes the concurrency configurable with a default of 10x messages.